### PR TITLE
Compatability update for ESPAsyncWiFiManager3.x not persisting wifi credentials after reboot

### DIFF
--- a/esp8266-hunter-sprinkler/src/wifi.cpp
+++ b/esp8266-hunter-sprinkler/src/wifi.cpp
@@ -20,6 +20,7 @@
 void setupWifi() {
     DNSServer dns;
 
+    WiFi.persistent(true); 
     AsyncWiFiManager wifiManager(&server, &dns);
     //wifiManager.resetSettings();
     


### PR DESCRIPTION
Should fix issue where wifi credentials not persisting reboots when using ESPAsyncWiFiManager 3.x
https://github.com/ecodina/hunter-wifi/issues/3